### PR TITLE
Compute Kuberntes service IPs from the service CIDR

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -5,7 +5,7 @@ resource "template_dir" "bootstrap-manifests" {
 
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
-    etcd_servers    = "${var.experimental_self_hosted_etcd ? format("http://%s:2379,http://127.0.0.1:12379", var.kube_etcd_service_ip) : join(",", var.etcd_servers)}"
+    etcd_servers    = "${var.experimental_self_hosted_etcd ? format("http://%s:2379,http://127.0.0.1:12379", cidrhost(var.service_cidr, 15)) : join(",", var.etcd_servers)}"
 
     cloud_provider = "${var.cloud_provider}"
     pod_cidr       = "${var.pod_cidr}"
@@ -20,13 +20,13 @@ resource "template_dir" "manifests" {
 
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
-    etcd_servers    = "${var.experimental_self_hosted_etcd ? format("http://%s:2379", var.kube_etcd_service_ip) : join(",", var.etcd_servers)}"
+    etcd_servers    = "${var.experimental_self_hosted_etcd ? format("http://%s:2379", cidrhost(var.service_cidr, 15)) : join(",", var.etcd_servers)}"
 
     cloud_provider = "${var.cloud_provider}"
+    
     pod_cidr       = "${var.pod_cidr}"
     service_cidr   = "${var.service_cidr}"
-
-    kube_dns_service_ip = "${var.kube_dns_service_ip}"
+    kube_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"

--- a/etcd-assets.tf
+++ b/etcd-assets.tf
@@ -6,7 +6,7 @@ data "template_file" "bootstrap-etcd" {
   template = "${file("${path.module}/resources/experimental/bootstrap-manifests/bootstrap-etcd.yaml")}"
   vars {
     etcd_image = "${var.container_images["etcd"]}"
-    bootstrap_etcd_service_ip = "${var.kube_bootstrap_etcd_service_ip}"
+    bootstrap_etcd_service_ip = "${cidrhost(var.service_cidr, 200)}"
   }
 }
 
@@ -19,7 +19,7 @@ resource "local_file" "bootstrap-etcd" {
 data "template_file" "bootstrap-etcd-service" {
   template = "${file("${path.module}/resources/etcd/bootstrap-etcd-service.json")}"
   vars {
-    bootstrap_etcd_service_ip = "${var.kube_bootstrap_etcd_service_ip}"
+    bootstrap_etcd_service_ip = "${cidrhost(var.service_cidr, 200)}"
   }
 }
 
@@ -32,7 +32,7 @@ resource "local_file" "bootstrap-etcd-service" {
 data "template_file" "etcd-tpr" {
   template = "${file("${path.module}/resources/etcd/migrate-etcd-cluster.json")}"
   vars {
-    bootstrap_etcd_service_ip = "${var.kube_bootstrap_etcd_service_ip}"
+    bootstrap_etcd_service_ip = "${cidrhost(var.service_cidr, 200)}"
   }
 }
 
@@ -55,7 +55,7 @@ resource "local_file" "etcd-operator" {
 data "template_file" "etcd-service" {
   template = "${file("${path.module}/resources/experimental/manifests/etcd-service.yaml")}"
   vars {
-    etcd_service_ip = "${var.kube_etcd_service_ip}"
+    etcd_service_ip = "${cidrhost(var.service_cidr, 15)}"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,14 @@ output "content_hash" {
   value = "${sha1("${template_dir.bootstrap-manifests.id} ${template_dir.manifests.id}")}"
 }
 
+output "kube_dns_service_ip" {
+  value = "${cidrhost(var.service_cidr, 10)}"
+}
+
+output "etcd_service_ip" {
+  value = "${cidrhost(var.service_cidr, 15)}"
+}
+
 output "kubeconfig" {
   value = "${data.template_file.kubeconfig.rendered}"
 }

--- a/tls.tf
+++ b/tls.tf
@@ -74,7 +74,7 @@ resource "tls_cert_request" "apiserver" {
   ]
 
   ip_addresses = [
-    "${var.kube_apiserver_service_ip}",
+    "${cidrhost(var.service_cidr, 1)}",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,10 @@ variable "pod_cidr" {
 }
 
 variable "service_cidr" {
-  description = "CIDR IP range to assign Kubernetes services"
+  description = <<EOD
+CIDR IP range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns, the 15th IP will be reserved for self-hosted etcd, and the 200th IP will be reserved for bootstrap self-hosted etcd.
+EOD
   type        = "string"
   default     = "10.3.0.0/24"
 }
@@ -49,30 +52,6 @@ variable "container_images" {
     hyperkube = "quay.io/coreos/hyperkube:v1.6.2_coreos.0"
     etcd = "quay.io/coreos/etcd:v3.1.6"
   }
-}
-
-variable "kube_apiserver_service_ip" {
-  description = "Kubernetes service IP for kube-apiserver (must be within service_cidr)"
-  type        = "string"
-  default     = "10.3.0.1"
-}
-
-variable "kube_dns_service_ip" {
-  description = "Kubernetes service IP for kube-dns (must be within server_cidr)"
-  type        = "string"
-  default     = "10.3.0.10"
-}
-
-variable "kube_etcd_service_ip" {
-  description = "Kubernetes service IP for self-hosted etcd (must be within server_cidr)"
-  type = "string"
-  default = "10.3.0.15"
-}
-
-variable "kube_bootstrap_etcd_service_ip" {
-  description = "Kubernetes service IP for bootstrapping self-hosted etcd (must be within server_cidr)"
-  type = "string"
-  default = "10.3.0.200"
 }
 
 variable "ca_certificate" {


### PR DESCRIPTION
Use the Terraform `cidrhost` interpolation, based on the same trick in use in https://github.com/coreos/tectonic-installer/pull/767.

This removes the ability to input the service IP's, but these were not truly customizable anyway. bootkube start has hardcoded assumptions about the offset for each service component.