### PR TITLE
Added basic CoreOS update operator manifest

### DIFF
--- a/operator-assets.tf
+++ b/operator-assets.tf
@@ -1,0 +1,10 @@
+# Operators
+
+# CoreOS Update Operator
+resource "local_file" "update-operator" {
+  count      = "${var.operators_update_service ? 1 : 0}"
+  depends_on = ["template_dir.manifests"]
+
+  content  = "${file("${path.module}/resources/operators/manifests/update-operator.yaml")}"
+  filename = "${var.asset_dir}/experimental/manifests/update-operator.yaml"
+}

--- a/resources/operators/manifests/update-operator.yaml
+++ b/resources/operators/manifests/update-operator.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: container-linux-update-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: container-linux-update-operator
+    spec:
+      containers:
+      - name: update-operator
+        image: quay.io/coreos/container-linux-update-operator:v0.2.0
+        command:
+        - "/bin/update-operator"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,8 @@ variable "ca_private_key" {
   type        = "string"
   default     = ""
 }
+
+variable "operators_update_service" {
+  description = "Create CoreOS update operator"
+  default = true
+}


### PR DESCRIPTION
This allows for CoreOS to update correctly when running Kubernetes by draining the node first, and that the node is back in-service within the cluster before releasing the lock.